### PR TITLE
mdp samples in C#

### DIFF
--- a/examples/C#/README.md
+++ b/examples/C#/README.md
@@ -272,3 +272,21 @@ Use with LPClient.
 	Usage: ./ZGuideExamples.exe EAgain
 ```
 
+#### [MDBroker](https://github.com/metadings/zguide/blob/master/examples/C%23/mdbroker.cs), [MDWorker](https://github.com/metadings/zguide/blob/master/examples/C%23/mdworker.cs), [MDClient](https://github.com/metadings/zguide/blob/master/examples/C%23/mdclient.cs)
+
+```
+	Usage: ./ZGuideExamples.exe MDBroker [-v] [--verbose]
+
+	    -v 		Verbose mode activated
+	            Default verbose is deactivated
+				
+	Usage: ./ZGuideExamples.exe MDWorker [-v] [--verbose]
+
+	    -v 		Verbose mode activated
+	            Default verbose is deactivated
+				
+	Usage: ./ZGuideExamples.exe MDClient [-v] [--verbose]
+
+	    -v 		Verbose mode activated
+	            Default verbose is deactivated
+```

--- a/examples/C#/ZGuideExamples.VS.csproj
+++ b/examples/C#/ZGuideExamples.VS.csproj
@@ -78,6 +78,12 @@
     <Compile Include="lpclient.cs" />
     <Compile Include="lpserver.cs" />
     <Compile Include="lvcache.cs" />
+    <Compile Include="mdbroker.cs" />
+    <Compile Include="mdcliapi.cs" />
+    <Compile Include="mdclient.cs" />
+    <Compile Include="mdp.cs" />
+    <Compile Include="mdworker.cs" />
+    <Compile Include="mdwrkapi.cs" />
     <Compile Include="msgqueue.cs" />
     <Compile Include="mspoller.cs" />
     <Compile Include="msreader.cs" />

--- a/examples/C#/mdbroker.cs
+++ b/examples/C#/mdbroker.cs
@@ -1,0 +1,605 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using ZeroMQ;
+
+namespace Examples
+{
+   using MDBroker; 
+
+    namespace MDBroker
+    {
+        public class Broker : IDisposable
+        {
+            //  Majordomo Protocol broker
+            //  A minimal C implementation of the Majordomo Protocol as defined in
+            //  http://rfc.zeromq.org/spec:7 and http://rfc.zeromq.org/spec:8.
+            
+            //  .split broker class structure
+            //  The broker class defines a single broker instance:
+
+            // Our Context
+            private ZContext _context;
+
+            //Socket for clients & workers
+            public ZSocket Socket;
+
+            //  Print activity to console
+            public bool Verbose { get; protected set; }
+
+            //  Broker binds to this endpoint
+            public string Endpoint { get; protected set; }
+
+            // Hash of known services
+            public Dictionary<string, Service> Services;
+
+            // Hash of known workes
+            public Dictionary<string, Worker> Workers;
+
+            // Waiting workers
+            public List<Worker> Waiting;
+
+            // When to send HEARTBEAT
+            public DateTime HeartbeatAt;
+
+            // waiting
+            // heartbeat_at
+
+            public Broker(bool verbose)
+            {
+                // Constructor
+                _context = new ZContext();
+
+                Socket = new ZSocket(_context, ZSocketType.ROUTER);
+
+                Verbose = verbose;
+
+                Services = new Dictionary<string, Service>(); //new HashSet<Service>();
+                Workers = new Dictionary<string, Worker>(); //new HashSet<Worker>();
+                Waiting = new List<Worker>();
+
+                HeartbeatAt = DateTime.UtcNow + MdpCommon.HEARTBEAT_INTERVAL;
+            }
+
+            ~Broker()
+            {
+                Dispose(false);
+            }
+
+            public void Dispose()
+            {
+                GC.SuppressFinalize(this);
+                Dispose(true);
+            }
+
+            protected void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    // Destructor
+                    if (Socket != null)
+                    {
+                        Socket.Dispose();
+                        Socket = null;
+                    }
+
+                    if (_context != null)
+                    {
+                        // Do Context.Dispose()
+                        _context.Dispose();
+                        _context = null;
+                    }
+                }
+            }
+
+            // added ShutdownContext, to call shutdown in main method.
+            public void ShutdownContext()
+            {
+                if (_context != null)
+                    _context.Shutdown();
+            }
+
+            /*
+            static void s_broker_bind(broker_t* self, char* endpoint);
+            static void s_broker_worker_msg(broker_t* self, zframe_t* sender, zmsg_t* msg);
+            static void s_broker_client_msg(broker_t* self, zframe_t* sender, zmsg_t* msg);
+            static void s_broker_purge(broker_t* self);
+            */
+
+            //  .split broker bind method
+            //  This method binds the broker instance to an endpoint. We can call
+            //  this multiple times. Note that MDP uses a single Socket for both clients 
+            //  and workers:
+            public void Bind(string endpoint)
+            {
+                Socket.Bind(endpoint);
+                // if you dont wanna see utc timeshift, remove zzz and use DateTime.UtcNow instead
+                "I: MDP broker/0.2.0 is active at {0}".DumpString(endpoint);
+            }
+
+            //  .split broker worker_msg method
+            //  This method processes one READY, REPLY, HEARTBEAT, or
+            //  DISCONNECT message sent to the broker by a worker:
+            public void WorkerMsg(ZFrame sender, ZMessage msg)
+            {
+                if(msg.Count < 1) // At least, command
+                    throw new InvalidOperationException();
+
+                ZFrame command = msg.Pop();
+                //string id_string = sender.ReadString();
+                bool isWorkerReady; 
+                //string id_string;
+                using (var sfrm = sender.Duplicate())
+                {
+                    var idString = sfrm.Read().ToHexString();
+                    isWorkerReady = Workers.ContainsKey(idString);
+                }
+                Worker worker = RequireWorker(sender);
+                using (msg)
+                {
+                    using (command)
+                    {
+                        
+                        if (command.StrHexEq(MdpCommon.MdpwCmd.READY))
+                        {
+                            if (isWorkerReady)
+                                // Not first command in session
+                                worker.Delete(true);
+                            else if (command.Length >= 4
+                                     && command.ToString().StartsWith("mmi."))
+                                // Reserd servicee name
+                                worker.Delete(true);
+                            else
+                            {
+                                // Attach worker to service and mark as idle
+                                using (ZFrame serviceFrame = msg.Pop())
+                                {
+                                    worker.Service = RequireService(serviceFrame);
+                                    worker.Service.Workers++;
+                                    worker.Waiting();
+                                }
+                            }
+                        }
+                        else if (command.StrHexEq(MdpCommon.MdpwCmd.REPLY))
+                        {
+                            if (isWorkerReady)
+                            {
+                                //  Remove and save client return envelope and insert the
+                                //  protocol header and service name, then rewrap envelope.
+                                ZFrame client = msg.Unwrap();
+                                msg.Prepend(new ZFrame(worker.Service.Name));
+                                msg.Prepend(new ZFrame(MdpCommon.MDPC_CLIENT));
+                                msg.Wrap(client);
+                                Socket.Send(msg);
+                                worker.Waiting();
+                            }
+                            else
+                            {
+                                worker.Delete(true);
+                            }
+                        }
+                        else if (command.StrHexEq(MdpCommon.MdpwCmd.HEARTBEAT))
+                        {
+                            if (isWorkerReady)
+                            {
+                                worker.Expiry = DateTime.UtcNow + MdpCommon.HEARTBEAT_EXPIRY;
+                            }
+                            else
+                            {
+                                worker.Delete(true);
+                            }
+                        }
+                        else if (command.StrHexEq(MdpCommon.MdpwCmd.DISCONNECT))
+                            worker.Delete(false);
+                        else
+                        {
+                            msg.DumpZmsg("E: invalid input message");
+                        }
+                    }
+                }
+            }
+
+            //  .split broker client_msg method
+            //  Process a request coming from a client. We implement MMI requests
+            //  directly here (at present, we implement only the mmi.service request):
+            public void ClientMsg(ZFrame sender, ZMessage msg)
+            {
+                // service & body
+                if(msg.Count < 2)
+                    throw new InvalidOperationException();
+
+                using (ZFrame serviceFrame = msg.Pop())
+                {
+                    Service service = RequireService(serviceFrame);
+
+                    // Set reply return identity to client sender
+                    msg.Wrap(sender.Duplicate());
+
+                    //if we got a MMI Service request, process that internally
+                    if (serviceFrame.Length >= 4
+                        && serviceFrame.ToString().StartsWith("mmi."))
+                    {
+                        string returnCode;
+                        if (serviceFrame.ToString().Equals("mmi.service"))
+                        {
+                            string name = msg.Last().ToString();
+                            returnCode = Services.ContainsKey(name) 
+                                         && Services[name].Workers > 0
+                                            ? "200"
+                                            : "400";
+                        }
+                        else
+                            returnCode = "501";
+
+                        using (var resetableFrame = msg.Pop())
+                        {
+                            msg.Prepend(new ZFrame(returnCode));
+                        }
+
+                        //ToDo check c implementation
+                        throw new NotImplementedException("ToDo: fix this section, never tested. contains errors mmi services never called with the mdclient/mdbroker/mdworker examples");
+                        //## following code has some errors
+
+                        //  Remove & save client return envelope and insert the
+                        //  protocol header and Service name, then rewrap envelope.
+                        ZFrame client = msg.Unwrap();
+                        msg.Prepend(serviceFrame);
+                        msg.Prepend(new ZFrame(MdpCommon.MDPC_CLIENT));
+                        msg.Wrap(client);
+                        Socket.Send(msg);
+                    }
+                    else
+                    {
+                        // Else dispatch the message to the requested Service
+                        service.Dispatch(msg);
+                    }
+                }
+            }
+
+            //  .split broker purge method
+            //  This method deletes any idle workers that haven't pinged us in a
+            //  while. We hold workers from oldest to most recent so we can stop
+            //  scanning whenever we find a live worker. This means we'll mainly stop
+            //  at the first worker, which is essential when we have large numbers of
+            //  workers (we call this method in our critical path):
+
+            public void Purge()
+            {
+                Worker worker = Waiting.FirstOrDefault();
+                while (worker != null)
+                {
+                    if (DateTime.UtcNow < worker.Expiry)
+                        break;   // Worker is alive, we're done here
+                    if(Verbose)
+                        "I: deleting expired worker: '{0}'".DumpString(worker.IdString);
+                    
+                    worker.Delete(false);
+                    worker = Waiting.FirstOrDefault();
+                }
+            }
+
+            //  .split service methods
+            //  Here is the implementation of the methods that work on a service:
+
+            //  Lazy constructor that locates a service by name or creates a new
+            //  service if there is no service already with that name.
+
+            public Service RequireService(ZFrame serviceFrame)
+            {
+                if(serviceFrame == null)
+                    throw new InvalidOperationException();
+
+                string name = serviceFrame.ToString();
+
+                Service service;
+                if (Services.ContainsKey(name))
+                {
+                    service = Services[name];
+                }
+                else
+                {
+                    service = new Service(this, name);
+                    Services[name] = service;
+
+                    //zhash_freefn(self->workers, id_string, s_worker_destroy);
+                    if (Verbose)
+                        "I: added service: '{0}'".DumpString(name);
+                }
+
+                return service;
+            }
+
+            //  .split worker methods
+            //  Here is the implementation of the methods that work on a worker:
+
+            //  Lazy constructor that locates a worker by identity, or creates a new
+            //  worker if there is no worker already with that identity.
+
+            public Worker RequireWorker(ZFrame identity)
+            {
+                if (identity == null)
+                    throw new InvalidOperationException();
+
+                string idString;
+                using (var tstfrm = identity.Duplicate())
+                {
+                    idString = tstfrm.Read().ToHexString();
+                }
+                
+                Worker worker = Workers.ContainsKey(idString)
+                    ? Workers[idString]
+                    : null;
+
+                if (worker == null)
+                {
+                    worker = new Worker(idString, this, identity);
+                    Workers[idString] = worker;
+                    if(Verbose)
+                        "I: registering new worker: '{0}'".DumpString(idString);
+                }
+                
+                return worker;
+            }
+        }
+
+        public class Service : IDisposable
+        {
+            // Broker Instance
+            public Broker Broker { get; protected set; }
+
+            // Service Name
+            public string Name { get; protected set; }
+
+            // List of client requests
+            public List<ZMessage> Requests { get; protected set; }
+
+            // List of waiting workers
+            public List<Worker> Waiting { get; protected set; }
+
+            // How many workers we are
+            public int Workers;
+            //ToDo check workers var
+
+            internal Service(Broker broker, string name)
+            {
+                Broker = broker;
+                Name = name; 
+                Requests = new List<ZMessage>();
+                Waiting = new List<Worker>();
+            }
+
+            ~Service()
+            {
+                Dispose(false);
+            }
+
+            public void Dispose()
+            {
+                GC.SuppressFinalize(this);
+                Dispose(true);
+            }
+
+            protected void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    foreach (var r in Requests)
+                    {
+                        // probably obsolete?
+                        using (r)
+                        {
+                        }
+                    }
+                }
+            }
+
+            //  .split service dispatch method
+            //  This method sends requests to waiting workers:
+            public void Dispatch(ZMessage msg)
+            {
+                if (msg != null) // queue msg if any
+                    Requests.Add(msg);
+
+                Broker.Purge();
+                while (Waiting.Count > 0
+                       && Requests.Count > 0)
+                {
+                    Worker worker = Waiting[0];
+                    Waiting.RemoveAt(0);
+                    Broker.Waiting.Remove(worker);
+                    ZMessage reqMsg = Requests[0];
+                    Requests.RemoveAt(0);
+                    using (reqMsg)
+                        worker.Send(MdpCommon.MdpwCmd.REQUEST.ToHexString(), null, reqMsg);
+                }
+            }
+        }
+
+        public class Worker
+        {
+            //  .split worker class structure
+            //  The worker class defines a single worker, idle or active:
+
+            // Broker Instance
+            public Broker Broker { get; protected set; }
+
+            // Identity of worker as string
+            public string IdString { get; protected set; }
+
+            // Identity frame for routing
+            public ZFrame Identity { get; protected set; }
+
+            //Ownling service, if known
+            public Service Service { get; set; }
+
+            //When worker expires, if no heartbeat; 
+            public DateTime Expiry { get; set; }
+
+            /// <summary>
+            /// 
+            /// </summary>
+            /// <param name="idString"></param>
+            /// <param name="broker"></param>
+            /// <param name="identity">will be dublicated inside the constructor</param>
+            public Worker(string idString, Broker broker, ZFrame identity)
+            {
+                Broker = broker;
+                IdString = idString;
+                Identity = identity.Duplicate();
+            }
+            ~Worker()
+            {
+                Dispose(false);
+            }
+
+            public void Dispose()
+            {
+                GC.SuppressFinalize(this);
+                Dispose(true);
+            }
+
+            protected void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    using (Identity)
+                    {}
+                }
+            }
+
+
+            public void Delete(bool disconnect)
+            {
+                if(disconnect)
+                    Send(MdpCommon.MdpwCmd.DISCONNECT.ToHexString(), null, null);
+
+                if (Service != null)
+                {
+                    Service.Waiting.Remove(this);
+                    Service.Workers--;
+                }
+
+                Broker.Waiting.Remove(this);
+                if (Broker.Workers.ContainsKey(IdString))
+                    Broker.Workers.Remove(IdString);
+            }
+
+            //  .split worker send method
+            //  This method formats and sends a command to a worker. The caller may
+            //  also provide a command option, and a message payload:
+            public void Send(string command, string option, ZMessage msg)
+            {
+                msg = msg != null
+                        ? msg.Duplicate()
+                        : new ZMessage();
+
+                // Stack protocol envelope to start of message
+                if (!string.IsNullOrEmpty(option))
+                    msg.Prepend(new ZFrame(option));
+                msg.Prepend(new ZFrame(command));
+                msg.Prepend(new ZFrame(MdpCommon.MDPW_WORKER));
+
+                // Stack routing envelope to start of message
+                msg.Wrap(Identity.Duplicate());
+
+                if(Broker.Verbose)
+                    msg.DumpZmsg("I: sending '{0:X}|{0}' to worker", command.ToMdCmd());
+
+                Broker.Socket.Send(msg);
+            }
+
+            // This worker is now waiting for work 
+            public void Waiting()
+            {
+                // queue to broker and service waiting lists
+                if (Broker == null)
+                    throw new InvalidOperationException();
+                Broker.Waiting.Add(this);
+                Service.Waiting.Add(this);
+                Expiry = DateTime.UtcNow + MdpCommon.HEARTBEAT_EXPIRY;
+                Service.Dispatch(null);
+            }
+        }
+    }
+
+    static partial class Program
+    {
+        //  .split main task
+        //  Finally, here is the main task. We create a new broker instance and
+        //  then process messages on the broker Socket:
+        public static void MDBroker(string[] args)
+        {
+            bool verbose = (args.Any(e => e.ToLower().Equals("-v")
+                                       || e.ToLower().Equals("--verbose")));
+            Console.WriteLine("Verbose: {0}", verbose);
+
+            CancellationTokenSource cancellor = new CancellationTokenSource();
+            Console.CancelKeyPress += (s, ea) =>
+            {
+                ea.Cancel = true;
+                cancellor.Cancel();
+            };
+
+            using (Broker broker = new Broker(verbose))
+            {
+                broker.Bind("tcp://*:5555");
+                // Get and process messages forever or until interrupted
+                while (true)
+                {
+                    if (cancellor.IsCancellationRequested
+                        || (Console.KeyAvailable && Console.ReadKey(true).Key == ConsoleKey.Escape))
+                        broker.ShutdownContext();
+
+                    var p = ZPollItem.CreateReceiver();
+                    ZMessage msg;
+                    ZError error;
+                    if (broker.Socket.PollIn(p, out msg, out error, MdpCommon.HEARTBEAT_INTERVAL))
+                    {
+                        if (verbose)
+                            msg.DumpZmsg("I: received message:");
+
+                        using (ZFrame sender = msg.Pop())
+                        using (ZFrame empty = msg.Pop())
+                        using (ZFrame header = msg.Pop())
+                        {
+                            if (header.ToString().Equals(MdpCommon.MDPC_CLIENT))
+                                broker.ClientMsg(sender, msg);
+                            else if (header.ToString().Equals(MdpCommon.MDPW_WORKER))
+                                broker.WorkerMsg(sender, msg);
+                            else
+                            {
+                                msg.DumpZmsg("E: invalid message:");
+                                msg.Dispose();
+                            }
+                        }
+                    }
+                    else
+                    {
+                        if (Equals(error, ZError.ETERM))
+                        {
+                            "W: interrupt received, shutting down...".DumpString();
+                            break; // Interrupted
+                        }
+                        if (!Equals(error, ZError.EAGAIN))
+                            throw new ZException(error);
+                    }
+                    // Disconnect and delete any expired workers
+                    // Send heartbeats to idle workes if needed
+                    if (DateTime.UtcNow > broker.HeartbeatAt)
+                    {
+                        broker.Purge();
+
+                        foreach (var waitingworker in broker.Waiting)
+                        {
+                            waitingworker.Send(MdpCommon.MdpwCmd.HEARTBEAT.ToHexString(), null, null);
+                        }
+                        broker.HeartbeatAt = DateTime.UtcNow + MdpCommon.HEARTBEAT_INTERVAL;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/examples/C#/mdcliapi.cs
+++ b/examples/C#/mdcliapi.cs
@@ -1,0 +1,206 @@
+﻿using System;
+using System.Threading;
+
+using ZeroMQ;
+
+namespace Examples
+{
+    namespace MDCliApi
+    {
+        //
+        //  mdcliapi class - Majordomo Protocol Client API
+        //  Implements the MDP/Worker spec at http://rfc.zeromq.org/spec:7.
+        //
+        // Author: metadings
+        //
+
+        public class MajordomoClient : IDisposable
+        {
+            //  Structure of our class
+            //  We access these properties only via class methods
+
+            // Our context
+            readonly ZContext _context;
+
+            // Majordomo broker
+            public string Broker { get; protected set; }
+
+            //  Socket to broker
+            public ZSocket Client { get; protected set; }
+
+            //  Print activity to console
+            public bool Verbose { get; protected set; }
+
+            //  Request timeout
+            public TimeSpan Timeout { get; protected set; }
+
+            //  Request retries
+            public int Retries { get; protected set; }
+
+
+
+            public void ConnectToBroker()
+            {
+                //  Connect or reconnect to broker
+
+                Client = new ZSocket(_context, ZSocketType.REQ);
+                Client.Connect(Broker);
+                if (Verbose)
+                    "I: connecting to broker at '{0}'...".DumpString(Broker);
+                
+            }
+
+            public MajordomoClient(string broker, bool verbose)
+            {
+                if(broker == null)
+                    throw new InvalidOperationException();
+                _context = new ZContext();
+                Broker = broker;
+                Verbose = verbose;
+                Timeout = TimeSpan.FromMilliseconds(2500);
+                Retries = 3;
+
+                ConnectToBroker();
+            }
+
+            ~MajordomoClient()
+            {
+                Dispose(false);
+            }
+
+            public void Dispose()
+            {
+                GC.SuppressFinalize(this);
+                Dispose(true);
+            }
+
+            protected void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    // Destructor
+
+                    if (Client != null)
+                    {
+                        Client.Dispose();
+                        Client = null;
+                    }
+                    //Do not Dispose Context: cuz of weird shutdown behavior, stucks in using calls 
+                }
+            }
+
+            //  .split configure retry behavior
+            //  These are the class methods. We can set the request timeout and number
+            //  of retry attempts before sending requests:
+
+            //  Set request timeout
+            public void Set_Timeout(int timeoutInMs)
+            {
+                Timeout = TimeSpan.FromMilliseconds(timeoutInMs);
+            }
+
+            //  Set request retries
+            public void Set_Retries(int retries)
+            {
+                Retries = retries;
+            }
+
+            //  .split send request and wait for reply
+            //  Here is the {{send}} method. It sends a request to the broker and gets
+            //  a reply even if it has to retry several times. It takes ownership of 
+            //  the request message, and destroys it when sent. It returns the reply
+            //  message, or NULL if there was no reply after multiple attempts:
+            public ZMessage Send(string service, ZMessage request, CancellationTokenSource cancellor)
+            {
+                if (request == null)
+                    throw new NotImplementedException();
+
+                //  Prefix request with protocol frames
+                //  Frame 1: "MDPCxy" (six bytes, MDP/Client x.y)
+                //  Frame 2: Service name (printable string)
+                request.Prepend(new ZFrame(service));
+                request.Prepend(new ZFrame(MdpCommon.MDPC_CLIENT));
+                if (Verbose)
+                    request.DumpZmsg("I: send request to '{0}' service:", service);
+
+                int retriesLeft = Retries;
+                while (retriesLeft > 0 && !cancellor.IsCancellationRequested)
+                {
+                    if (cancellor.IsCancellationRequested
+                        || (Console.KeyAvailable && Console.ReadKey(true).Key == ConsoleKey.Escape))
+                        _context.Shutdown();
+
+                    // Copy the Request and send on Client
+                    ZMessage msgreq = request.Duplicate();
+
+                    ZError error;
+                    if (!Client.Send(msgreq, out error))
+                    {
+                        if (Equals(error, ZError.ETERM))
+                        {
+                            cancellor.Cancel();
+                            break; // Interrupted
+                        }
+                    }
+
+                    var p = ZPollItem.CreateReceiver();
+                    ZMessage msg;
+                    //  .split body of send 
+                    //  On any blocking call, {{libzmq}} will return -1 if there was
+                    //  an error; we could in theory check for different error codes,
+                    //  but in practice it's OK to assume it was {{EINTR}} (Ctrl-C):
+
+                    // Poll the client Message
+                    if (Client.PollIn(p, out msg, out error, Timeout))
+                    {
+                        //  If we got a reply, process it
+                        if (Verbose)
+                            msg.DumpZmsg("I: received reply");
+
+                        if(msg.Count < 3)
+                            throw new InvalidOperationException();
+
+                        using (ZFrame header = msg.Pop())
+                            if (!header.ToString().Equals(MdpCommon.MDPC_CLIENT))
+                                throw new InvalidOperationException();
+
+                        using (ZFrame replyService = msg.Pop())
+                            if(!replyService.ToString().Equals(service))
+                                throw new InvalidOperationException();
+
+                        request.Dispose();
+                        return msg;
+                    }
+                    else if (Equals(error, ZError.ETERM))
+                    {
+                        cancellor.Cancel();
+                        break; // Interrupted
+                    }
+                    else if (Equals(error, ZError.EAGAIN))
+                    {
+                        if (--retriesLeft > 0)
+                        {
+                            if (Verbose)
+                                "W: no reply, reconnecting...".DumpString();
+
+                            ConnectToBroker();
+                        }
+                        else
+                        {
+                            if (Verbose)
+                                "W: permanent error, abandoning".DumpString();
+                            break; // Give up
+                        }
+                    }
+                }
+                if (cancellor.IsCancellationRequested)
+                {
+                    "W: interrupt received, killing client...\n".DumpString();
+                }
+                request.Dispose();
+                return null;
+            }
+
+        }
+    }
+}

--- a/examples/C#/mdclient.cs
+++ b/examples/C#/mdclient.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using ZeroMQ;
+
+namespace Examples
+{
+    using MDCliApi; // Let us build this source without creating a library
+    static partial class Program
+    {
+        //  Majordomo Protocol client example
+        //  Uses the mdcli API to hide all MDP aspects
+        public static void MDClient(string[] args)
+        {
+            bool verbose = (args.Any(e => e.ToLower().Equals("-v")
+                                       || e.ToLower().Equals("--verbose")));
+            Console.WriteLine("Verbose: {0}", verbose);
+
+            CancellationTokenSource cts = new CancellationTokenSource();
+            Console.CancelKeyPress += (s, ea) =>
+            {
+                ea.Cancel = true;
+                cts.Cancel();
+            };
+
+            using (MajordomoClient session = new MajordomoClient("tcp://localhost:5555", verbose))
+            {
+                int count;
+                for (count = 0; count < 100000; count++)
+                {
+                    ZMessage request = new ZMessage();
+                    request.Prepend(new ZFrame("Hello world"));
+                    using (ZMessage reply = session.Send("echo", request, cts))
+                        if (reply == null)
+                            break; // Interrupt or failure
+                }
+                Console.WriteLine("{0} requests/replies processed\n", count);
+            }
+        }
+    }
+}

--- a/examples/C#/mdp.cs
+++ b/examples/C#/mdp.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using ZeroMQ;
+
+namespace Examples
+{
+
+    public static class MdpCommon
+    {
+        public const int HEARTBEAT_LIVENESS = 3;
+
+        public static readonly TimeSpan HEARTBEAT_DELAY = TimeSpan.FromMilliseconds(2500);
+        public static readonly TimeSpan RECONNECT_DELAY = TimeSpan.FromMilliseconds(2500);
+
+        public static readonly TimeSpan HEARTBEAT_INTERVAL = TimeSpan.FromMilliseconds(2500);
+        public static readonly TimeSpan HEARTBEAT_EXPIRY =
+            TimeSpan.FromMilliseconds(HEARTBEAT_INTERVAL.TotalMilliseconds * HEARTBEAT_LIVENESS);
+
+        public static readonly string MDPW_WORKER = "MDPW01";
+        public static readonly string MDPC_CLIENT = "MDPC01";
+
+        //public static readonly string READY = "001";
+        //public static readonly string REQUEST = "002";
+        //public static readonly string REPLY = "003";
+        //public static readonly string HEARTBEAT = "004";
+        //public static readonly string DISCONNECT = "005";
+
+        public enum MdpwCmd : byte { READY = 1, REQUEST = 2, REPLY = 3, HEARTBEAT = 4, DISCONNECT = 5 }
+    }
+
+    public static class MdpExtensions
+    {
+        public static bool StrHexEq(this ZFrame zfrm, MdpCommon.MdpwCmd cmd)
+        {
+            return zfrm.ToString().ToMdCmd().Equals(cmd);
+        }
+
+        /// <summary>
+        /// Parse hex value to MdpwCmd, if parsing fails, return 0
+        /// </summary>
+        /// <param name="hexval">hex string</param>
+        /// <returns>MdpwCmd, return 0 if parsing failed</returns>
+        public static MdpCommon.MdpwCmd ToMdCmd(this string hexval)
+        {
+            try
+            {
+                MdpCommon.MdpwCmd cmd = (MdpCommon.MdpwCmd)byte.Parse(hexval, NumberStyles.AllowHexSpecifier);
+                return cmd;
+            }
+            catch (FormatException)
+            {
+                return 0;
+            }
+        }
+
+        public static string ToHexString(this MdpCommon.MdpwCmd cmd)
+        {
+            return cmd.ToString("X");
+        }
+
+        public static void DumpString(this string format, params object[] args)
+        {
+            // if you dont wanna see utc timeshift, remove zzz and use DateTime.UtcNow instead
+            Console.WriteLine("[{0}] - {1}", string.Format("{0:yyyy-MM-ddTHH:mm:ss:fffffff zzz}", DateTime.Now), string.Format(format, args));
+        }
+
+        /// <summary>
+        /// Based on zmsg_dump 
+        /// https://github.com/imatix/zguide/blob/f94e8995a5e02d843434ace904a7afc48e266b3f/articles/src/multithreading/zmsg.c
+        /// </summary>
+        /// <param name="zmsg"></param>
+        /// <param name="format"></param>
+        /// <param name="args"></param>
+        public static void DumpZmsg(this ZMessage zmsg, string format, params object[] args)
+        {
+            format.DumpString(args);
+            using (var dmsg = zmsg.Duplicate())
+                foreach (var zfrm in dmsg)
+                {
+                    byte[] data = zfrm.Read();
+                    long size = zfrm.Length;
+
+                    // Dump the message as text or binary
+                    bool isText = true;
+                    for (int i = 0; i < size; i++)
+                        if (data[i] < 32 || data[i] > 127)
+                            isText = false;
+                    string datastr = isText ? Encoding.UTF8.GetString(data) : data.ToHexString();
+                    "\tD: [{0,3:D3}]:{1}".DumpString(size, datastr);
+                }
+        }
+    }
+
+}

--- a/examples/C#/mdworker.cs
+++ b/examples/C#/mdworker.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using ZeroMQ;
+
+namespace Examples
+{
+    using MDWrkApi; // Let us build this source without creating a library
+
+    static partial class Program
+    {
+        //  Majordomo Protocol worker example
+        //  Uses the mdwrk API to hide all MDP aspects
+        public static void MDWorker(string[] args)
+        {
+            bool verbose = (args.Any(e => e.ToLower().Equals("-v")
+                                       || e.ToLower().Equals("--verbose")));
+            Console.WriteLine("Verbose: {0}", verbose);
+
+            CancellationTokenSource cts = new CancellationTokenSource();
+            Console.CancelKeyPress += (s, ea) =>
+            {
+                ea.Cancel = true;
+                cts.Cancel();
+            };
+
+            using (MajordomoWorker session = new MajordomoWorker("tcp://localhost:5555", "echo", verbose))
+            {
+                ZMessage reply = null;
+                while (true)
+                {
+                    ZMessage request = session.Recv(reply, cts);
+                    if (request == null)
+                        break; // worker was interrupted
+                    reply = request; // Echo is complex
+                }
+            }
+        }
+    }
+}

--- a/examples/C#/mdwrkapi.cs
+++ b/examples/C#/mdwrkapi.cs
@@ -1,0 +1,270 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+
+using ZeroMQ;
+
+namespace Examples
+{
+    namespace MDWrkApi
+    {
+        //
+        //  mdwrkapi class - Majordomo Protocol Worker API
+        //  Implements the MDP/Worker spec at http://rfc.zeromq.org/spec:7.
+        //
+        // Author: metadings
+        //
+
+        public class MajordomoWorker : IDisposable
+        {
+            //  Structure of our class
+            //  We access these properties only via class methods
+
+            // Our context
+            private ZContext _context;
+
+            // Majordomo broker
+            public string Broker { get; protected set; }
+            public string Service { get; protected set; }
+
+            //  Socket to broker
+            public ZSocket Worker { get; protected set; }
+
+            //  Print activity to console
+            public bool Verbose { get; protected set; }
+
+
+            #region Heartbeat management
+
+            // When to send HEARTBEAT
+            public DateTime HeartbeatAt { get; protected set; }
+
+            // How many attempts left
+            public UInt64 Liveness { get; protected set; }
+
+            // Heartbeat delay, msecs
+            public TimeSpan Heartbeat { get; protected set; }
+
+            // Reconnect delay, msecs
+            public TimeSpan Reconnect { get; protected set; }
+
+            #endregion
+
+            #region Unknown to port
+
+            // Zero only at start
+            private bool _expectReply;
+
+            // Return identity, if any
+            private ZFrame _replyTo;
+
+            #endregion
+
+
+            public void SendToBroker(string command, string option, ZMessage msg)
+            {
+                using (msg = msg != null ? msg.Duplicate() : new ZMessage())
+                {
+                    if (!string.IsNullOrEmpty(option))
+                        msg.Prepend(new ZFrame(option));
+                    msg.Prepend(new ZFrame(command));
+                    msg.Prepend(new ZFrame(MdpCommon.MDPW_WORKER));
+                    msg.Prepend(new ZFrame(string.Empty));
+
+                    if (Verbose)
+                        msg.DumpZmsg("I: sending '{0:X}|{0}' to broker", command.ToMdCmd());
+
+                    Worker.Send(msg);
+                }
+            }
+
+            public void ConnectToBroker()
+            {
+                //  Connect or reconnect to broker
+                Worker = new ZSocket(_context, ZSocketType.DEALER);
+                Worker.Connect(Broker);
+                if (Verbose)
+                    "I: connecting to broker at {0}...".DumpString(Broker);
+
+                // Register service with broker
+                SendToBroker(MdpCommon.MdpwCmd.READY.ToHexString(), Service, null);
+
+                // if liveness hits zero, queue is considered disconnected
+                Liveness = MdpCommon.HEARTBEAT_LIVENESS; 
+                HeartbeatAt = DateTime.UtcNow + Heartbeat;
+            }
+
+            public MajordomoWorker(string broker, string service, bool verbose)
+            {
+                if(broker == null)
+                    throw new InvalidOperationException();
+                if(service == null)
+                    throw new InvalidOperationException();
+
+                _context = new ZContext();
+                Broker = broker;
+                Service = service;
+                Verbose = verbose;
+                Heartbeat = MdpCommon.HEARTBEAT_DELAY;
+                Reconnect = MdpCommon.RECONNECT_DELAY;
+
+                ConnectToBroker();
+            }
+
+            ~MajordomoWorker()
+            {
+                Dispose(false);
+            }
+
+            public void Dispose()
+            {
+                GC.SuppressFinalize(this);
+                Dispose(true);
+            }
+
+            protected void Dispose(bool disposing)
+            {
+                if (disposing)
+                {
+                    // Destructor
+
+                    if (Worker != null)
+                    {
+                        Worker.Dispose();
+                        Worker = null;
+                    }
+                    //Do not Dispose Context: cuz of weird shutdown behavior, stucks in using calls
+                }
+            }
+
+            //  .split configure worker
+            //  We provide two methods to configure the worker API. You can set the
+            //  heartbeat interval and retries to match the expected network performance.
+
+            //  Set heartbeat delay
+            public void Set_Heartbeat(int heartbeatInMs)
+            {
+                Heartbeat = TimeSpan.FromMilliseconds(heartbeatInMs);
+            }
+
+            //  Set reconnect delay
+            public void Set_Reconnect(int reconnectInMs)
+            {
+                Reconnect = TimeSpan.FromMilliseconds(reconnectInMs);
+            }
+
+
+            //  .split recv method
+            //  This is the {{recv}} method; it's a little misnamed because it first sends
+            //  any reply and then waits for a new request. If you have a better name
+            //  for this, let me know.
+
+            //  Send reply, if any, to broker and wait for next request.
+            public ZMessage Recv(ZMessage reply, CancellationTokenSource cancellor)
+            {
+                if (reply == null
+                    && _expectReply)
+                    throw new InvalidOperationException();
+
+                if (reply != null)
+                {
+                    if(_replyTo == null)
+                        throw new InvalidOperationException();
+                    reply.Wrap(_replyTo);
+                    SendToBroker(MdpCommon.MdpwCmd.REPLY.ToHexString(), string.Empty, reply);
+                }
+                _expectReply = true;
+
+                while (true)
+                {
+                    if (cancellor.IsCancellationRequested
+                        || (Console.KeyAvailable && Console.ReadKey(true).Key == ConsoleKey.Escape))
+                        _context.Shutdown();
+
+                    var p = ZPollItem.CreateReceiver();
+                    ZMessage msg;
+                    ZError error;
+                    if (Worker.PollIn(p, out msg, out error, Heartbeat))
+                    {
+                        using (msg)
+                        {
+                            // If we got a reply
+                            if (Verbose)
+                                msg.DumpZmsg("I: received message from broker:");
+
+                            Liveness = MdpCommon.HEARTBEAT_LIVENESS;
+
+                            // Don't try to handle errors, just assert noisily
+                            if(msg.Count < 3)
+                                throw new InvalidOperationException();
+
+                            using (ZFrame empty = msg.Pop())
+                            {
+                                if (!empty.ToString().Equals(""))
+                                    throw new InvalidOperationException();
+                            }
+
+                            using (ZFrame header = msg.Pop())
+                            {
+                                if (!header.ToString().Equals(MdpCommon.MDPW_WORKER))
+                                    throw new InvalidOperationException();
+                            }
+                            //header.ReadString().Equals(MDPW_WORKER);
+                            using (ZFrame command = msg.Pop())
+                            {
+                                if (command.StrHexEq(MdpCommon.MdpwCmd.REQUEST))
+                                {
+                                    //  We should pop and save as many addresses as there are
+                                    //  up to a null part, but for now, just save one...
+                                    _replyTo = msg.Unwrap();
+
+                                    //  .split process message
+                                    //  Here is where we actually have a message to process; we
+                                    //  return it to the caller application:
+                                    return msg.Duplicate();
+                                }
+                                else if (command.StrHexEq(MdpCommon.MdpwCmd.HEARTBEAT))
+                                {
+                                    // Do nothing for heartbeats
+                                }
+                                else if (command.StrHexEq(MdpCommon.MdpwCmd.DISCONNECT))
+                                {
+                                    ConnectToBroker();
+                                }
+                                else
+                                    "E: invalid input message: '{0}'".DumpString(command.ToString());
+                            }
+                        }
+                    }
+                    else if (Equals(error, ZError.ETERM))
+                    {
+                        cancellor.Cancel();
+                        break; // Interrupted
+                    }
+                    else if (Equals(error, ZError.EAGAIN) 
+                             && --Liveness == 0)
+                    {
+                        if (Verbose)
+                            "W: disconnected from broker - retrying...".DumpString();
+                        Thread.Sleep(Reconnect);
+                        ConnectToBroker();
+                    }
+
+                    // Send HEARTBEAT if it's time
+                    if (DateTime.UtcNow > HeartbeatAt)
+                    {
+                        SendToBroker(MdpCommon.MdpwCmd.HEARTBEAT.ToHexString(), null, null);
+                        HeartbeatAt = DateTime.UtcNow + Heartbeat;
+                    }
+                }
+                if (cancellor.IsCancellationRequested)
+                    "W: interrupt received, killing worker...\n".DumpString();
+
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implemented Majordomopattern samples in C#:
- mdp.cs contains helper classes to dump messages like zclock_log and dump zmessage
- interrupts are implemented like in interrupt.cs with Console.Cancelkey Event and ESC check.
- broker client message is not fulfilled implemented. .mmi reset bytes on given message. but this section is never used for these examples, ill port this later. 
- verbose mode is much slower than the c implementation running on unix shell, cuz of dumping the message with console.writeline. For full speed, start the examples without verbose.
